### PR TITLE
feat: use proper btc and eth prices

### DIFF
--- a/src/lib/graphQL/queries.ts
+++ b/src/lib/graphQL/queries.ts
@@ -57,12 +57,15 @@ export const QUERY_RENVM_HISTORY = (
 
     volume {
       symbol
+      amount
+      amountInEth
       amountInUsd
     }
 
     locked {
       symbol
       amount
+      amountInEth
       amountInUsd
     }
   }`;
@@ -102,12 +105,15 @@ export interface RawRenVM {
 
     volume: Array<{
         symbol: string;
+        amount: string;
+        amountInEth: string;
         amountInUsd: string;
     }>;
 
     locked: Array<{
         symbol: string;
         amount: string;
+        amountInEth: string;
         amountInUsd: string;
         // asset: {
         //     decimals: string;
@@ -123,6 +129,8 @@ export interface PeriodData extends Omit<Omit<RawRenVM, "volume">, "locked"> {
         string,
         {
             symbol: string;
+            amount: string;
+            amountInEth: string;
             amountInUsd: string;
         }
     >;
@@ -132,6 +140,7 @@ export interface PeriodData extends Omit<Omit<RawRenVM, "volume">, "locked"> {
         {
             symbol: string;
             amount: string;
+            amountInEth: string;
             amountInUsd: string;
             // asset: {
             //     decimals: string;


### PR DESCRIPTION
Currently, if the volume is shown in BTC, it's converted from renBTC's price to USD at the time of the transfer, and back to BTC at the current price.

This PR fixes it to skip the conversion to USD when showing amounts in BTC or ETH.