### PR TITLE
fix: revert locked value price changes

### DIFF
--- a/src/lib/graphQL/queries.ts
+++ b/src/lib/graphQL/queries.ts
@@ -65,7 +65,6 @@ export const QUERY_RENVM_HISTORY = (
     locked {
       symbol
       amount
-      amountInEth
       amountInUsd
     }
   }`;
@@ -113,7 +112,6 @@ export interface RawRenVM {
     locked: Array<{
         symbol: string;
         amount: string;
-        amountInEth: string;
         amountInUsd: string;
         // asset: {
         //     decimals: string;
@@ -140,7 +138,6 @@ export interface PeriodData extends Omit<Omit<RawRenVM, "volume">, "locked"> {
         {
             symbol: string;
             amount: string;
-            amountInEth: string;
             amountInUsd: string;
             // asset: {
             //     decimals: string;


### PR DESCRIPTION
When using historic prices, if in a given period 1 BTC is burnt but the price of BTC goes up, the Total Locked value goes up, and by more than what's shown in the volume. This isn't incorrect - just a different definition of a period's change in total locked value.