### PR TITLE
feat: add arbitrum stats

### DIFF
--- a/src/controllers/pages/networkStatsPage/ChainSelector.tsx
+++ b/src/controllers/pages/networkStatsPage/ChainSelector.tsx
@@ -9,6 +9,7 @@ export enum ChainOption {
     Polygon = "Polygon",
     Avalanche = "Avalanche",
     Solana = "Solana",
+    Arbitrum = "Arbitrum",
 }
 
 const ChainDotColors = {
@@ -19,6 +20,7 @@ const ChainDotColors = {
     [ChainOption.Polygon]: "#8247e5",
     [ChainOption.Avalanche]: "#e84142",
     [ChainOption.Solana]: "#00ffbd",
+    [ChainOption.Arbitrum]: "#28A0F0",
 };
 
 export const ChainLineColors = {
@@ -29,16 +31,20 @@ export const ChainLineColors = {
     [ChainOption.Polygon]: "#8247e5",
     [ChainOption.Avalanche]: "#e84142",
     [ChainOption.Solana]: "#00ffbd",
+    [ChainOption.Arbitrum]: "#28A0F0",
 };
 
 export const ChainLineColorsTransparent = {
     [ChainOption.All]: "#006FE8",
+
+    // 66 opacity added:
     [ChainOption.Ethereum]: "#627EEA66",
     [ChainOption.BinanceSmartChain]: "#F9B72D66",
     [ChainOption.Fantom]: "#1969ff66",
     [ChainOption.Polygon]: "#8247e566",
     [ChainOption.Avalanche]: "#e8414266",
     [ChainOption.Solana]: "#00ffbd66",
+    [ChainOption.Arbitrum]: "#28A0F066",
 };
 
 export const ChainLabel: Record<ChainOption, string> = {
@@ -49,9 +55,10 @@ export const ChainLabel: Record<ChainOption, string> = {
     [ChainOption.Polygon]: "Polygon",
     [ChainOption.Avalanche]: "Avalanche",
     [ChainOption.Solana]: "Solana",
+    [ChainOption.Arbitrum]: "Arbitrum",
 };
 
-const availableChains: Array<ChainOption> = [
+export const availableChains: Array<ChainOption> = [
     ChainOption.All,
     ChainOption.Ethereum,
     ChainOption.BinanceSmartChain,
@@ -59,6 +66,7 @@ const availableChains: Array<ChainOption> = [
     ChainOption.Polygon,
     ChainOption.Avalanche,
     ChainOption.Solana,
+    ChainOption.Arbitrum,
 ];
 
 const ChainDotDiv = styled.div`

--- a/src/controllers/pages/networkStatsPage/VolumeData.tsx
+++ b/src/controllers/pages/networkStatsPage/VolumeData.tsx
@@ -20,6 +20,7 @@ import { ReactComponent as IconValueLocked } from "../../../styles/images/icon-v
 import { ReactComponent as IconVolume } from "../../../styles/images/icon-volume.svg";
 import { Stat } from "../../../views/Stat";
 import {
+    availableChains,
     ChainLabel,
     ChainLineColors,
     ChainLineColorsTransparent,
@@ -136,15 +137,7 @@ export const VolumeStats: React.FC<VolumeStatsProps> = ({
     ]);
 
     const linesData: Line[] = useMemo(() => {
-        return [
-            ChainOption.All,
-            ChainOption.Ethereum,
-            ChainOption.BinanceSmartChain,
-            ChainOption.Fantom,
-            ChainOption.Polygon,
-            ChainOption.Avalanche,
-            ChainOption.Solana,
-        ].map((chainOptionInner) => {
+        return availableChains.map((chainOptionInner) => {
             let series: Array<[number, number]> = [];
             if (!volumeLoading && tokenPrices) {
                 if (chainOptionInner !== ChainOption.All) {

--- a/src/lib/graphQL/queries/renVmTracker.ts
+++ b/src/lib/graphQL/queries/renVmTracker.ts
@@ -19,6 +19,7 @@ export enum TrackerChain {
     Fantom = "Fantom",
     Avalanche = "Avalanche",
     Solana = "Solana",
+    Arbitrum = "Arbitrum",
 }
 
 const allTrackedChains: Array<TrackerChain> = [
@@ -28,6 +29,7 @@ const allTrackedChains: Array<TrackerChain> = [
     TrackerChain.Polygon,
     TrackerChain.Avalanche,
     TrackerChain.Solana,
+    TrackerChain.Arbitrum,
 ];
 
 export const chainOptionToTrackerChain = (chain: ChainOption) => {
@@ -44,6 +46,8 @@ export const chainOptionToTrackerChain = (chain: ChainOption) => {
             return TrackerChain.Avalanche;
         case ChainOption.Solana:
             return TrackerChain.Solana;
+        case ChainOption.Arbitrum:
+            return TrackerChain.Arbitrum;
         default:
             return TrackerChain.Ethereum;
     }


### PR DESCRIPTION
In preparation for RenVM Arbitrum support.

TODO: Ideally we should only have to list host-chains in one file together with the chain's label and colour, rather than having to update various different mappings in different files.