### PR TITLE
feat: add ENS reverse resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     },
     "dependencies": {
         "@apollo/react-hooks": "^4.0.0",
+        "@ensdomains/ensjs": "^2.0.1",
         "@fortawesome/free-regular-svg-icons": "^5.15.4",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
         "@fortawesome/react-fontawesome": "^0.1.15",

--- a/src/controllers/common/header/AccountDropdown.tsx
+++ b/src/controllers/common/header/AccountDropdown.tsx
@@ -9,12 +9,8 @@ export const AccountDropdown: React.FC = () => {
     const [shown, setShown] = useState(false);
     const [copied, setCopied] = useState(false);
 
-    const {
-        address,
-        web3BrowserName,
-        promptLogin,
-        logout,
-    } = Web3Container.useContainer();
+    const { address, ensName, web3BrowserName, promptLogin, logout } =
+        Web3Container.useContainer();
 
     const ref = useRef(null as HTMLDivElement | null);
 
@@ -78,7 +74,11 @@ export const AccountDropdown: React.FC = () => {
                                 {web3BrowserName}{" "}
                             </div>
                             <div className="header--account--address">
-                                {address.substring(0, 8)}...{address.slice(-5)}
+                                {ensName ??
+                                    `${address.substring(
+                                        0,
+                                        8,
+                                    )}...${address.slice(-5)}`}
                             </div>
                         </div>
                     </>

--- a/src/store/web3Container.tsx
+++ b/src/store/web3Container.tsx
@@ -18,6 +18,8 @@ import { toChecksumAddress } from "web3-utils";
 
 import BigNumber from "bignumber.js";
 import Notify, { API as NotifyInstance } from "bnc-notify";
+// @ts-ignore
+import ENS, { getEnsAddress } from "@ensdomains/ensjs";
 import { LoggedOut } from "../controllers/common/popups/LoggedOut";
 import { getWeb3BrowserName, Web3Browser } from "../lib/ethereum/browsers";
 import { getReadOnlyWeb3 } from "../lib/ethereum/getWeb3";
@@ -200,6 +202,7 @@ const useWeb3Container = (initialState = RenNetwork.Testnet) => {
 
     // Login data
     const [address, setAddress] = useState<string | null>(null);
+    const [ensName, setEnsName] = useState<string | null>(null);
     const [web3BrowserName, setWeb3BrowserName] = useState(
         Web3Browser.Web3Browser,
     );
@@ -297,11 +300,30 @@ const useWeb3Container = (initialState = RenNetwork.Testnet) => {
         }
     }, [walletAddress, address, clearPopup, logout, setPopup]);
 
+    useEffect(() => {
+        const resolveEnsAddress = async () => {
+            if (address && web3.currentProvider) {
+                const ens = new ENS({
+                    provider: web3.currentProvider,
+                    ensAddress: getEnsAddress("1"),
+                });
+
+                const ensName = await ens.getName(address);
+                setEnsName(ensName.name);
+            } else {
+                setEnsName(null);
+            }
+        };
+
+        resolveEnsAddress();
+    }, [address, web3, setEnsName]);
+
     return {
         renNetwork,
         web3,
         setWeb3,
         address,
+        ensName,
         balance,
         web3BrowserName,
         setWeb3BrowserName,


### PR DESCRIPTION
# ENS name resolution

Display ENS name instead of address.

![image](https://user-images.githubusercontent.com/1225563/145816689-d4857ae0-9ab2-406e-93e8-2c5458e7f73c.png)

## Changes
- added new dependency `@ensdomains/ensjs`
- updated `useWeb3Container` hook including a new side effect to resolve ENS names.
- updated `AccountDropdown` component to display the ENS name instead of the address whenever possible.

## Notes
Future changes might include displaying the ENS avatar instead of the visual hash, but I wanted to keep this PR as lean as possible to introduce the concept.