### PR TITLE
feat: update 'Total Network Fees' stat

### DIFF
--- a/src/controllers/pages/darknodeStatsPage/DarknodeStatsPage.tsx
+++ b/src/controllers/pages/darknodeStatsPage/DarknodeStatsPage.tsx
@@ -1,4 +1,5 @@
 import BigNumber from "bignumber.js";
+import { OrderedMap } from "immutable";
 import React, { useEffect, useMemo, useState } from "react";
 
 import { Loading } from "@renproject/react-components";
@@ -8,8 +9,12 @@ import {
     getFeesCollection,
     getFundCollection,
 } from "../../../lib/darknode/utils/feesUtils";
+import { Token } from "../../../lib/ethereum/tokens";
 import { isDefined } from "../../../lib/general/isDefined";
-import { multiplyTokenAmount } from "../../../lib/graphQL/queries/queries";
+import {
+    multiplyTokenAmount,
+    TokenAmount,
+} from "../../../lib/graphQL/queries/queries";
 import { GithubAPIContainer } from "../../../store/githubApiContainer";
 import { GraphContainer } from "../../../store/graphContainer";
 import { MapContainer } from "../../../store/mapContainer";
@@ -26,9 +31,6 @@ import { updatePrices } from "../../common/tokenBalanceUtils";
 import { mergeFees } from "../darknodePage/blocks/FeesBlockController";
 import { OverviewDiv } from "./DarknodeStatsStyles";
 import { FeesStat } from "./FeesStat";
-import { TokenAmount } from "../../../lib/graphQL/queries/queries";
-import { OrderedMap } from "immutable";
-import { Token } from "../../../lib/ethereum/tokens";
 
 const REN_TOTAL_SUPPLY = new BigNumber(1000000000);
 interface ZapperToken {
@@ -230,14 +232,13 @@ export const DarknodeStatsPage = () => {
               new BigNumber(0),
           )
         : null;
-    const totalFeesInUsdMerged = totalFeesRenVmInUsd;
-    // totalFeesRenVmInUsd
-    // ? totalFeesRenVmInUsd.plus(totalFeesInUsd || 0)
-    // : null;
-    const totalFeesMerged = totalFeesRenVm;
-    // fees && totalFeesRenVm
-    //     ? mergeFees(totalFeesRenVm, fees)
-    //     : totalFeesRenVm;
+    const totalFeesInUsdMerged = totalFeesRenVmInUsd
+        ? totalFeesRenVmInUsd.plus(totalFeesInUsd || 0)
+        : null;
+    const totalFeesMerged =
+        fees && totalFeesRenVm
+            ? mergeFees(totalFeesRenVm, fees)
+            : totalFeesRenVm;
 
     const currentInUsd =
         currentCycle && pendingTotalInUsd.get(currentCycle, undefined);

--- a/src/lib/darknode/utils/feesUtils.ts
+++ b/src/lib/darknode/utils/feesUtils.ts
@@ -1,6 +1,12 @@
 import BigNumber from "bignumber.js";
+
 import { updatePrice } from "../../../controllers/common/tokenBalanceUtils";
-import { FeeTokens, Token, TokenPrices, AllTokenDetails } from "../../ethereum/tokens";
+import {
+    AllTokenDetails,
+    FeeTokens,
+    Token,
+    TokenPrices,
+} from "../../ethereum/tokens";
 import { TokenAmount } from "../../graphQL/queries/queries";
 import {
     BlockState,
@@ -46,8 +52,8 @@ export const getClaimFeeForToken = (symbol: string, blockState: BlockState) => {
         .plus(dustAmount)
         .plus(1);
     const feeDivisor = AllTokenDetails.get(Token[symbol])?.feeDivisor;
-    if(feeDivisor) {
-        fee =  fee.div(new BigNumber(Math.pow(10, feeDivisor)));
+    if (feeDivisor) {
+        fee = fee.div(new BigNumber(Math.pow(10, feeDivisor)));
     }
     return fee;
 };
@@ -63,9 +69,9 @@ export const getMinimumAmountForToken = (
     const { minimumAmount } = data;
     const fee = getClaimFeeForToken(symbol, blockState);
     const feeDivisor = AllTokenDetails.get(Token[symbol])?.feeDivisor;
-    return feeDivisor ?
-        fee.plus(minimumAmount).div(new BigNumber(Math.pow(10, feeDivisor))) :
-        fee.plus(minimumAmount);
+    return feeDivisor
+        ? fee.plus(minimumAmount).div(new BigNumber(Math.pow(10, feeDivisor)))
+        : fee.plus(minimumAmount);
 };
 
 export const getFeeDataForToken = (symbol: string, blockState: BlockState) => {
@@ -325,6 +331,9 @@ export const getAggregatedFeeAmountForToken = (
                 (sum, epoch) => sum.plus(epoch.amount),
                 new BigNumber(0),
             );
+        }
+        if (fees) {
+            amount = amount.plus(fees.unassigned);
         }
     }
     return amount;


### PR DESCRIPTION
The 'Total Network Fees' stat doesn't include 1) legacy fees collected on Ethereum and 2) fees that will be paid out in the current epoch (and future epochs). This PR fixes the stat to include both.

The old stat showed 200 BTC whereas the new stat shows 529 BTC. As a quick verification that the new figure is correct, we can take the all-time BTC volume (325k BTC) and multiply it by a fee average of 15 BPS and we get 488 BTC in fees, which is much closer to the new stat.